### PR TITLE
Improve performance of ispackedtoapp implementation

### DIFF
--- a/AssetRelationsViewer/Editor/AssetRelationsViewerWindow.cs
+++ b/AssetRelationsViewer/Editor/AssetRelationsViewerWindow.cs
@@ -52,6 +52,7 @@ namespace Com.Innogames.Core.Frontend.AssetRelationsViewer
 		private Dictionary<string, VisualizationNodeData> _cachedVisualizationNodeDatas = new Dictionary<string, VisualizationNodeData>();
 		private Dictionary<string, AssetCacheData> _cachedNodes = new Dictionary<string, AssetCacheData>();
 		private Dictionary<string, int> _cachedSizes = new Dictionary<string, int>();
+		private Dictionary<string, bool> _cachedPackedInfo = new Dictionary<string, bool>();
 
 		private Stack<UndoStep> _undoSteps = new Stack<UndoStep>();
 		
@@ -788,7 +789,7 @@ namespace Com.Innogames.Core.Frontend.AssetRelationsViewer
 				
 				data.Name = typeHandler.GetName(id);
 				data.IsEditorAsset = nodeHandler.IsNodeEditorOnly(id, type);
-				data.IsPackedToApp = NodeDependencyLookupUtility.IsNodePackedToApp(id, type, _nodeDependencyLookupContext, new HashSet<string>());
+				data.IsPackedToApp = NodeDependencyLookupUtility.IsNodePackedToApp(id, type, _nodeDependencyLookupContext, _cachedPackedInfo);
 
 				_cachedVisualizationNodeDatas.Add(key, data);
 			}
@@ -804,6 +805,7 @@ namespace Com.Innogames.Core.Frontend.AssetRelationsViewer
 		private void Refresh()
 		{
 			_cachedSizes.Clear();
+			_cachedPackedInfo.Clear();
 			_cachedVisualizationNodeDatas.Clear();
 			_cachedNodes.Clear();
 			InvalidateNodeStructure();

--- a/AssetRelationsViewer/Editor/AssetTypeHandler.cs
+++ b/AssetRelationsViewer/Editor/AssetTypeHandler.cs
@@ -102,20 +102,20 @@ namespace Com.Innogames.Core.Frontend.AssetRelationsViewer
         {
             _viewerWindow = window;
             _filteredNodes = CreateFilter(_filterString);
-
-            if (_explorerSyncModePref.GetValue())
-            {
-                RegisterOnSelectionChanged();
-            }
-            else
-            {
-                UnregisterOnSelectionChanged();
-            }
+            Selection.selectionChanged += HandleSyncToExplorer;
         }
 
         public bool HandlesCurrentNode()
         {
             return _selectedAsset != null;
+        }
+        
+        private void HandleSyncToExplorer()
+        {
+            if (_explorerSyncModePref.GetValue())
+            {
+                _viewerWindow.OnAssetSelectionChanged();
+            }
         }
 
         private void DisplayFilterOptions()
@@ -143,29 +143,8 @@ namespace Com.Innogames.Core.Frontend.AssetRelationsViewer
                 _viewerWindow.InvalidateNodeStructure();
             }
 
-            AssetRelationsViewerWindow.TogglePref(_explorerSyncModePref, "Sync to explorer:", b =>
-            {
-                if (b)
-                {
-                    RegisterOnSelectionChanged();
-                }
-                else
-                {
-                    UnregisterOnSelectionChanged();
-                }
-            });
-
+            AssetRelationsViewerWindow.TogglePref(_explorerSyncModePref, "Sync to explorer:");
             EditorGUILayout.EndVertical();
-        }
-
-        private void RegisterOnSelectionChanged()
-        {
-            Selection.selectionChanged += _viewerWindow.OnAssetSelectionChanged;
-        }
-
-        private void UnregisterOnSelectionChanged()
-        {
-            Selection.selectionChanged -= _viewerWindow.OnAssetSelectionChanged;
         }
 
         private HashSet<string> CreateFilter(string filter)

--- a/NodeDependencyLookup/Editor/Caches/AssetDependencyCache/AssetDependencyCache.cs
+++ b/NodeDependencyLookup/Editor/Caches/AssetDependencyCache/AssetDependencyCache.cs
@@ -18,7 +18,7 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 	 */
 	public class AssetDependencyCache : IDependencyCache
 	{
-		public const string Version = "1.10";
+		public const string Version = "1.30";
 		public const string FileName = "AssetDependencyCacheData_" + Version + ".cache";
 
 		private FileToAssetNode[] _fileToAssetNodes = new FileToAssetNode[0];
@@ -42,6 +42,7 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 
 		public void Load(string directory)
 		{
+			EditorUtility.DisplayProgressBar("AssetDependencyCache", "Loading cache", 0);
 			string path = Path.Combine(directory, FileName);
 
 			if (_isLoaded)
@@ -62,6 +63,7 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 
 		public void Save(string directory)
 		{
+			EditorUtility.DisplayProgressBar("AssetDependencyCache", "Saving cache", 0);
 			string path = Path.Combine(directory, FileName);
 
 			if (!Directory.Exists(directory))

--- a/NodeDependencyLookup/Editor/Caches/AssetDependencyCache/AssetDependencyCacheSerializer.cs
+++ b/NodeDependencyLookup/Editor/Caches/AssetDependencyCache/AssetDependencyCacheSerializer.cs
@@ -53,8 +53,6 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 			
 			CacheSerializerUtils.EncodeString(EOF, ref bytes, ref offset);
 
-			Deserialize(bytes);
-			
 			return bytes;
 		}
 		
@@ -85,7 +83,6 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 				{
 					string assetId = CacheSerializerUtils.DecodeString(ref bytes, ref offset);
 					AssetNode assetNode = new AssetNode(assetId);
-
 					int numResolverDatas = CacheSerializerUtils.DecodeShort(ref bytes, ref offset);
 
 					for (int j = 0; j < numResolverDatas; ++j)
@@ -94,7 +91,6 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 						
 						data.ResolverId = CacheSerializerUtils.DecodeString(ref bytes, ref offset);
 						data.Dependencies = CacheSerializerUtils.DecodeDependencies(ref bytes, ref offset);
-						
 						assetNode.ResolverDatas.Add(data);
 					}
 

--- a/NodeDependencyLookup/Editor/Caches/AssetDependencyCache/AssetTraverser/AssetSerializedPropertyTraverser.cs
+++ b/NodeDependencyLookup/Editor/Caches/AssetDependencyCache/AssetTraverser/AssetSerializedPropertyTraverser.cs
@@ -94,16 +94,8 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 			do
 			{
 				SerializedPropertyType propertyType = property.propertyType;
-				
-				if (propertyType == SerializedPropertyType.Character |
-				    propertyType == SerializedPropertyType.Integer |
-				    propertyType == SerializedPropertyType.Float |
-				    propertyType == SerializedPropertyType.String |
-				    propertyType == SerializedPropertyType.Vector4 |
-				    propertyType == SerializedPropertyType.Vector2 |
-				    propertyType == SerializedPropertyType.Vector3 |
-				    propertyType == SerializedPropertyType.ArraySize
-				    )
+
+				if (propertyType != SerializedPropertyType.ObjectReference && propertyType != SerializedPropertyType.Generic)
 				{
 					continue;
 				}

--- a/NodeDependencyLookup/Editor/Caches/OpenSceneDependencyCache.cs
+++ b/NodeDependencyLookup/Editor/Caches/OpenSceneDependencyCache.cs
@@ -312,9 +312,9 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
             return 0;
         }
 
-        public bool IsNodePackedToApp(string id, string type)
+        public bool IsNodePackedToApp(string id, string type, bool alwaysExcluded)
         {
-            return true;
+            return false;
         }
 
         public bool IsNodeEditorOnly(string id, string type)

--- a/NodeDependencyLookup/Editor/NodeHandler/AssetNodeHandler.cs
+++ b/NodeDependencyLookup/Editor/NodeHandler/AssetNodeHandler.cs
@@ -26,26 +26,20 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 			return 0;
 		}
 
-		public bool IsNodePackedToApp(string id, string type)
+		public bool IsNodePackedToApp(string id, string type, bool alwaysExcluded = false)
 		{
-			string path = AssetDatabase.GUIDToAssetPath(id);
-
-			if (IsNodeEditorOnly(id, type))
+			if (alwaysExcluded)
 			{
-				return false;
+				return !IsNodeEditorOnly(id, type);
 			}
-
-			/*if (IsSceneAndPacked(path) || IsInResources(path))
-			{
-				return true;
-			}*/
-
-			return false;
+			
+			string path = AssetDatabase.GUIDToAssetPath(NodeDependencyLookupUtility.GetGuidFromAssetId(id));
+			return IsSceneAndPacked(path) || IsInResources(path) || id.StartsWith("0000000");
 		}
 
 		public bool IsNodeEditorOnly(string id, string type)
 		{
-			string path = AssetDatabase.GUIDToAssetPath(id);
+			string path = AssetDatabase.GUIDToAssetPath(NodeDependencyLookupUtility.GetGuidFromAssetId(id));
 			return path.Contains("/Editor/");
 		}
 

--- a/NodeDependencyLookup/Editor/NodeHandler/FileNodeHandler.cs
+++ b/NodeDependencyLookup/Editor/NodeHandler/FileNodeHandler.cs
@@ -26,21 +26,15 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
             return NodeDependencyLookupUtility.GetPackedAssetSize(id);
         }
 
-        public bool IsNodePackedToApp(string id, string type)
+        public bool IsNodePackedToApp(string id, string type, bool alwaysExcluded)
         {
+            if (alwaysExcluded)
+            {
+                return !IsNodeEditorOnly(id, type);
+            }
+			
             string path = AssetDatabase.GUIDToAssetPath(id);
-
-            if (IsNodeEditorOnly(id, type))
-            {
-                return false;
-            }
-
-            if (IsSceneAndPacked(path) || IsInResources(path))
-            {
-                return true;
-            }
-
-            return false;
+            return IsSceneAndPacked(path) || IsInResources(path) || id.StartsWith("0000000");
         }
 
         public bool IsNodeEditorOnly(string id, string type)

--- a/NodeDependencyLookup/Editor/NodeHandler/INodeHandler.cs
+++ b/NodeDependencyLookup/Editor/NodeHandler/INodeHandler.cs
@@ -12,7 +12,7 @@
 		// Returns the filesize if the node. In case of an asset it would be the serialized filesize
 		int GetOwnFileSize(string id, string type, NodeDependencyLookupContext stateContext);
 		// Returns if a node is packed to the app or not. Helpful to find out if an asset is actually used in the final game or not
-		bool IsNodePackedToApp(string id, string type);
+		bool IsNodePackedToApp(string id, string type, bool alwaysExcluded = false);
 		// Returns if a node it just used within the editor. For assets this would be case if its in an editor folder
 		bool IsNodeEditorOnly(string id, string type);
 		// Returns if the assets contributes to the overall tree size (size of all dependencies together)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you are in production and not want to get automatic updates always use a tagg
 
 ```js
 	...
-    "com.innogames.asset-relations-viewer": "https://github.com/innogames/asset-relations-viewer.git#1.2.4",
+    "com.innogames.asset-relations-viewer": "https://github.com/innogames/asset-relations-viewer.git#1.3.0",
     ...
 
 ```

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+**1.3.0**
+ - Fixed several bugs regarding detection of if an asset is packed into the app or not and added cache to speed up the detection
+ - Fixed issue that added components to a PrefabInstance didnt show the usage of their script as a dependency
+
 **1.2.4**
  - Increased version to make a new release
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 **1.3.0**
  - Fixed several bugs regarding detection of if an asset is packed into the app or not and added cache to speed up the detection
  - Fixed issue that added components to a PrefabInstance didnt show the usage of their script as a dependency
+ - Fixed that once "Sync to explorer" option in asset type handler it could not get disabled anymore
+ - Increased serialized version to 1.3 to force
+ - Added progressbars for loading and saving the AssetDependencyCache
 
 **1.2.4**
  - Increased version to make a new release

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "com.innogames.asset-relations-viewer",
   "displayName": "Asset Relations Viewer",
   "description": "Editor UI for displaying dependencies between assets in a tree based view",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "unity": "2018.4",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Fixed issue with the IsPackedToApp function together with cyclic dependencies taking a lot of time since IsPackedToApp result wasnt cached.
Added fix for "Sync with explorer" option which could not be disabled anymore once it was enabled.
Added progressbars for loading and saving of the AssetDependencyCache