### PR TITLE
Added check for in package scenes

### DIFF
--- a/NodeDependencyLookup/Editor/Caches/AssetDependencyCache/AssetTraverser/AssetTraverser.cs
+++ b/NodeDependencyLookup/Editor/Caches/AssetDependencyCache/AssetTraverser/AssetTraverser.cs
@@ -48,6 +48,11 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 			var sceneAsset = obj as SceneAsset;
 			string path = AssetDatabase.GetAssetPath(sceneAsset);
 
+			if (path.StartsWith("Packages"))
+			{
+				return;
+			}
+
 			Scene scene = EditorSceneManager.OpenScene(path, OpenSceneMode.Additive);
 
 			TraverseObject(id, obj, new Stack<PathSegment>(), false);

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+**1.3.1**
+	- Scenes from packages are avoided from being scanned since they cant be loaded from readonly packages
+
 **1.3.0**
  - Fixed several bugs regarding detection of if an asset is packed into the app or not and added cache to speed up the detection
  - Fixed issue that added components to a PrefabInstance didnt show the usage of their script as a dependency

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "com.innogames.asset-relations-viewer",
   "displayName": "Asset Relations Viewer",
   "description": "Editor UI for displaying dependencies between assets in a tree based view",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "unity": "2018.4",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
In case a scene is inside the packages folder it is now avoided since scenes cant be loaded from the packages folder if the package is readonly.