### PR TITLE
Fix overflow exception if project has more than 32767 assets

### DIFF
--- a/NodeDependencyLookup/Editor/Caches/AssetDependencyCache/AssetDependencyCache.cs
+++ b/NodeDependencyLookup/Editor/Caches/AssetDependencyCache/AssetDependencyCache.cs
@@ -18,7 +18,7 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 	 */
 	public class AssetDependencyCache : IDependencyCache
 	{
-		private const string Version = "1.4.3";
+		private const string Version = "1.4.5";
 		private const string FileName = "AssetDependencyCacheData";
 		private const string VersionedFileName = FileName + "_" + Version + ".cache";
 

--- a/NodeDependencyLookup/Editor/Caches/AssetDependencyCache/AssetDependencyCacheSerializer.cs
+++ b/NodeDependencyLookup/Editor/Caches/AssetDependencyCache/AssetDependencyCacheSerializer.cs
@@ -16,7 +16,7 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 			byte[] bytes = new byte[CacheSerializerUtils.ARRAY_SIZE_OFFSET];
 			int offset = 0;
 			
-			CacheSerializerUtils.EncodeShort((short)fileToAssetNodes.Length, ref bytes, ref offset);
+			CacheSerializerUtils.EncodeLong(fileToAssetNodes.Length, ref bytes, ref offset);
 
 			foreach (FileToAssetNode fileToAssetNode in fileToAssetNodes)
 			{
@@ -59,7 +59,7 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 		public static FileToAssetNode[] Deserialize(byte[] bytes)
 		{
 			int offset = 0;
-			int numFileToAssetNodes = CacheSerializerUtils.DecodeShort(ref bytes, ref offset);
+			int numFileToAssetNodes = (int)CacheSerializerUtils.DecodeLong(ref bytes, ref offset);
 			
 			FileToAssetNode[] fileToAssetNodes = new FileToAssetNode[numFileToAssetNodes];
 

--- a/NodeDependencyLookup/Editor/Caches/AssetToFileDependencyCache/AssetToFileDependencyCache.cs
+++ b/NodeDependencyLookup/Editor/Caches/AssetToFileDependencyCache/AssetToFileDependencyCache.cs
@@ -15,7 +15,7 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
     // Cache to find get mapping of assets to the file the asset is included in
     public class AssetToFileDependencyCache : IDependencyCache
     {
-        private const string Version = "1.40";
+        private const string Version = "1.4.5";
         private const string FileName = "AssetToFileDependencyCacheData_" + Version + ".cache";
 
         private Dictionary<string, GenericDependencyMappingNode> _fileNodesDict = new Dictionary<string, GenericDependencyMappingNode>();

--- a/NodeDependencyLookup/Editor/Caches/AssetToFileDependencyCache/AssetToFileDependencyCacheSerializer.cs
+++ b/NodeDependencyLookup/Editor/Caches/AssetToFileDependencyCache/AssetToFileDependencyCacheSerializer.cs
@@ -12,7 +12,7 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 			byte[] bytes = new byte[CacheSerializerUtils.ARRAY_SIZE_OFFSET];
 			int offset = 0;
 			
-			CacheSerializerUtils.EncodeShort((short)assetToFileMappings.Length, ref bytes, ref offset);
+			CacheSerializerUtils.EncodeLong(assetToFileMappings.Length, ref bytes, ref offset);
 			
 			foreach (FileToAssetsMapping fileToAssetsMapping in assetToFileMappings)
 			{
@@ -38,7 +38,7 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 		public static FileToAssetsMapping[] Deserialize(byte[] bytes)
 		{
 			int offset = 0;
-			int numAssetToFileNodes = CacheSerializerUtils.DecodeShort(ref bytes, ref offset);
+			int numAssetToFileNodes = (int)CacheSerializerUtils.DecodeLong(ref bytes, ref offset);
 			
 			FileToAssetsMapping[] assetToFileMappings = new FileToAssetsMapping[numAssetToFileNodes];
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+**1.4.5**
+- Fixed issue that total amount of supported assets was limited to max size of short but is now limitted to max size of int.
+
 **1.4.4**
 - Added support for Unity 2021.3.x
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "com.innogames.asset-relations-viewer",
   "displayName": "Asset Relations Viewer",
   "description": "Editor UI for displaying dependencies between assets in a tree based view",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "unity": "2018.4",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Instead of using short to store the length of the amount of assets in the AssetDependencyCacheSerializer it is now stored as a long