### PR TITLE
Faster reflection

### DIFF
--- a/NodeDependencyLookup/Editor/Caches/AssetDependencyCache/AssetTraverser/AssetSerializedPropertyTraverser.cs
+++ b/NodeDependencyLookup/Editor/Caches/AssetDependencyCache/AssetTraverser/AssetSerializedPropertyTraverser.cs
@@ -10,7 +10,7 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 {
 	public class AssetSerializedPropertyTraverser : AssetTraverser
 	{
-		private struct ReflectionStackItem
+		private class ReflectionStackItem
 		{
 			public string fieldName;
 			public int arrayIndex;
@@ -82,15 +82,13 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 
 			Type objType = obj.GetType();
 
-			bool isReflectable = false;
-
-			if (!isReflectableCache.TryGetValue(objType, out isReflectable))
+			if (!isReflectableCache.TryGetValue(objType, out bool isReflectable))
 			{
 				isReflectable = objType.GetFields(Flags).Length > 0;
 				isReflectableCache[objType] = isReflectable;
 			}
 
-			ref ReflectionStackItem rootItem = ref ReflectionStack[0];
+			ReflectionStackItem rootItem = ReflectionStack[0];
 			rootItem.value = obj;
 			rootItem.type = objType;
 
@@ -126,7 +124,7 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 					}
 
 					string modifiedPath = propertyPath.Replace(".Array.data[", "[");
-					int stackIndex = propertyType == SerializedPropertyType.Generic ? UpdateStack(modifiedPath, ReflectionStack, property.isArray) : -1;
+					int stackIndex = propertyType == SerializedPropertyType.Generic ? UpdateStack(modifiedPath, ReflectionStack) : -1;
 
 					object generic = stackIndex != -1 ? ReflectionStack[stackIndex].value : (propertyType == SerializedPropertyType.ObjectReference ? property.objectReferenceValue : null);
 
@@ -140,7 +138,7 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 			} while (property.Next(propertyType == SerializedPropertyType.Generic));
 		}
 
-		private int UpdateStack(string path, ReflectionStackItem[] stack, bool isArray)
+		private int UpdateStack(string path, ReflectionStackItem[] stack)
 		{
 			int subIndex = 0;
 			int tokenCount = 0;

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+**1.5.0**
+- AssetDependencyCache update is now a lot faster due to improved reflection code
+- "Calculating all node sizes" step is now faster since it now only calculates reachable nodes
+
 **1.4.5**
 - Fixed issue that total amount of supported assets was limited to max size of short but is now limitted to max size of int.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "com.innogames.asset-relations-viewer",
   "displayName": "Asset Relations Viewer",
   "description": "Editor UI for displaying dependencies between assets in a tree based view",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "unity": "2018.4",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Improved reflection speed by only recalculating reflection of current property depth as well as ignoring types from reflection that cant be reflected like Transforms, MeshRenderers, etc.

Also improved speed of calculating node sizes by only include nodes that are reachable from the current tree.