### PR TITLE
Remove warning

### DIFF
--- a/AssetRelationsViewer/Editor/AssetRelationsViewerWindow.cs
+++ b/AssetRelationsViewer/Editor/AssetRelationsViewerWindow.cs
@@ -145,13 +145,18 @@ namespace Com.Innogames.Core.Frontend.AssetRelationsViewer
 #endif
 		}
 
+		[MenuItem("Window/Asset Relations Viewer/Open")]
+		public static void Open()
+		{
+			ShowWindow();
+		}
+
 		private static void ShowWindowForAssetInternal()
 		{
 			AssetRelationsViewerWindow window = ShowWindow();
 			window.OnAssetSelectionChanged();
 		}
 
-		[MenuItem("Window/Asset Relations Viewer/Open")]
 		public static AssetRelationsViewerWindow ShowWindow()
 		{
 			AssetRelationsViewerWindow window = GetWindow<AssetRelationsViewerWindow>(false, OwnName);

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+**1.5.2**
+- Remove warning
+
 **1.5.1**
 - Increase serialize version of AssetToFileDependencyCache because of dependency order change
 - Fixed possible StackOverflowException with very huge dependency trees and ShowAdditionalInformation option being enabled

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "com.innogames.asset-relations-viewer",
   "displayName": "Asset Relations Viewer",
   "description": "Editor UI for displaying dependencies between assets in a tree based view",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "unity": "2018.4",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Removed warning `Method Com.Innogames.Core.Frontend.AssetRelationsViewer.AssetRelationsViewerWindow.ShowWindow has invalid parameters. MenuCommand is the only optional supported parameter`