### PR TITLE
Change SerializedProperty traversal to use NextVisible() instead of Next()

### DIFF
--- a/NodeDependencyLookup/Editor/Caches/AssetDependencyCache/AssetTraverser/AssetSerializedPropertyTraverser.cs
+++ b/NodeDependencyLookup/Editor/Caches/AssetDependencyCache/AssetTraverser/AssetSerializedPropertyTraverser.cs
@@ -12,6 +12,9 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 	/// </summary>
 	public class AssetSerializedPropertyTraverser : AssetTraverser
 	{
+		private static int TraversablePropertyTypes = (1 << (int)SerializedPropertyType.ObjectReference) |
+		                                              (1 << (int)SerializedPropertyType.Generic) | (1 << (int)SerializedPropertyType.ManagedReference);
+
 		private readonly Stack<PathSegment> pathSegmentStack = new Stack<PathSegment>();
 
 		private readonly HashSet<Type> excludedTypes = new HashSet<Type>
@@ -65,15 +68,13 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 			unsafeModeMethod.SetValue(property, true);
 			property.Next(true);
 
-			SerializedPropertyType propertyType;
+			var traverseChildren = false;
 
 			do
 			{
-				propertyType = property.propertyType;
+				var propertyType = property.propertyType;
 
-				if (propertyType != SerializedPropertyType.ObjectReference &&
-				    propertyType != SerializedPropertyType.Generic &&
-				    propertyType != SerializedPropertyType.ManagedReference)
+				if ((TraversablePropertyTypes & (1 << (int)propertyType)) == 0)
 				{
 					continue;
 				}
@@ -82,7 +83,10 @@ namespace Com.Innogames.Core.Frontend.NodeDependencyLookup
 				{
 					TraverseProperty(searchContext, property, propertyType, property.propertyPath, stack);
 				}
-			} while (property.Next(propertyType == SerializedPropertyType.Generic || propertyType == SerializedPropertyType.ManagedReference));
+
+				traverseChildren = propertyType == SerializedPropertyType.Generic ||
+					propertyType == SerializedPropertyType.ManagedReference;
+			} while (property.NextVisible(traverseChildren));
 
 			serializedObject.Dispose();
 		}

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+**4.3.0**
+- Use NextVisible() instead of Next() to avoid recursive SerializedProperties
+  - In Unity 6000.3.x uxml assets have a back reference to the parent property leading to children.parent.children.parent. recursion
+
 **4.2.0**
 - Fix compile issue for UNITY_6000_4_OR_NEWER due to API change for AssetDatabaseExperimental.LookupArtifact()
 - Remove support of Unity 2019

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "com.innogames.asset-relations-viewer",
   "displayName": "Asset Relations Viewer",
   "description": "Editor UI for displaying dependencies between assets in a tree based view",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "unity": "2019.4",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Due to Unity 6000.3.x changing the serialized property structure of uxml files to contain a back reference to the parent this leads to an endless recursion when using Next() to traverse all children. To "fix" this now NextVisible() is used instead. 
This unfortunately will not find a [HideInspector] field anymore as a dependency after this change.